### PR TITLE
Do not render type pill for DataLake

### DIFF
--- a/electron/renderer/index.js
+++ b/electron/renderer/index.js
@@ -57,6 +57,7 @@ appRegistry.emit('data-service-initialized', dataService);
 dataService.connect((error, ds) => {
   global.hadronApp.dataService = ds;
   appRegistry.emit('data-service-connected', error, ds);
+  appRegistry.emit('instance-refreshed', { instance: { dataLake: { isDataLake: false, version: '1.0.0' }}});
 });
 
 if (module.hot) {

--- a/src/components/deployment-awareness.jsx
+++ b/src/components/deployment-awareness.jsx
@@ -20,7 +20,8 @@ class DeploymentAwarenessComponent extends React.Component {
   static propTypes = {
     servers: PropTypes.array,
     setName: PropTypes.string,
-    topologyType: PropTypes.string
+    topologyType: PropTypes.string,
+    isDataLake: PropTypes.bool
   }
 
   /**
@@ -31,7 +32,7 @@ class DeploymentAwarenessComponent extends React.Component {
   renderTopologyInfo() {
     switch (this.props.topologyType) {
       case SINGLE:
-        return (<Single server={this.props.servers[0]} />);
+        return (<Single server={this.props.servers[0]} isDataLake={this.props.isDataLake}/>);
       case SHARDED:
         return (<Sharded servers={this.props.servers} />);
       case REPLICA_SET_NO_PRIMARY:

--- a/src/components/single.jsx
+++ b/src/components/single.jsx
@@ -12,7 +12,16 @@ class Single extends React.Component {
   static displayName = 'Single';
 
   static propTypes = {
-    server: PropTypes.object.isRequired
+    server: PropTypes.object.isRequired,
+    isDataLake: PropTypes.bool.isRequired
+  }
+
+  renderPill() {
+    return (
+      <div className={classnames(styles['topology-single-type'])}>
+        {humanize(this.props.server.type)}
+      </div>
+    );
   }
 
   /**
@@ -26,9 +35,7 @@ class Single extends React.Component {
         <div className={classnames(styles['topology-single-address'])}>
           {this.props.server.address}
         </div>
-        <div className={classnames(styles['topology-single-type'])}>
-          {humanize(this.props.server.type)}
-        </div>
+        { this.props.isDataLake ? null : this.renderPill() }
       </div>
     );
   }

--- a/src/components/single.spec.js
+++ b/src/components/single.spec.js
@@ -18,7 +18,7 @@ describe('<Single />', () => {
   describe('#render', () => {
     context('when the server is standalone', () => {
       const server = { address: '127.0.0.1:27017', type: STANDALONE };
-      const component = shallow(<Single server={server} />);
+      const component = shallow(<Single server={server} isDataLake={false} />);
 
       it('renders the address', () => {
         const node = component.find(`.${styles['topology-single-address']}`);
@@ -33,7 +33,7 @@ describe('<Single />', () => {
 
     context('when the server is a primary', () => {
       const server = { address: '127.0.0.1:27017', type: RS_PRIMARY };
-      const component = shallow(<Single server={server} />);
+      const component = shallow(<Single server={server} isDataLake={false} />);
 
       it('renders the address', () => {
         const node = component.find(`.${styles['topology-single-address']}`);
@@ -48,7 +48,7 @@ describe('<Single />', () => {
 
     context('when the server is a secondary', () => {
       const server = { address: '127.0.0.1:27017', type: RS_SECONDARY };
-      const component = shallow(<Single server={server} />);
+      const component = shallow(<Single server={server} isDataLake={false} />);
 
       it('renders the address', () => {
         const node = component.find(`.${styles['topology-single-address']}`);
@@ -63,7 +63,7 @@ describe('<Single />', () => {
 
     context('when the server is an arbiter', () => {
       const server = { address: '127.0.0.1:27017', type: RS_ARBITER };
-      const component = shallow(<Single server={server} />);
+      const component = shallow(<Single server={server} isDataLake={false} />);
 
       it('renders the address', () => {
         const node = component.find(`.${styles['topology-single-address']}`);
@@ -78,7 +78,7 @@ describe('<Single />', () => {
 
     context('when the server is a ghost', () => {
       const server = { address: '127.0.0.1:27017', type: RS_GHOST };
-      const component = shallow(<Single server={server} />);
+      const component = shallow(<Single server={server} isDataLake={false} />);
 
       it('renders the address', () => {
         const node = component.find(`.${styles['topology-single-address']}`);
@@ -93,7 +93,7 @@ describe('<Single />', () => {
 
     context('when the server is unknown', () => {
       const server = { address: '127.0.0.1:27017', type: UNKNOWN };
-      const component = shallow(<Single server={server} />);
+      const component = shallow(<Single server={server} isDataLake={false} />);
 
       it('renders the address', () => {
         const node = component.find(`.${styles['topology-single-address']}`);
@@ -108,7 +108,7 @@ describe('<Single />', () => {
 
     context('when the server is an other', () => {
       const server = { address: '127.0.0.1:27017', type: RS_OTHER };
-      const component = shallow(<Single server={server} />);
+      const component = shallow(<Single server={server} isDataLake={false} />);
 
       it('renders the address', () => {
         const node = component.find(`.${styles['topology-single-address']}`);
@@ -123,7 +123,7 @@ describe('<Single />', () => {
 
     context('when the server is a possible primary', () => {
       const server = { address: '127.0.0.1:27017', type: POSSIBLE_PRIMARY };
-      const component = shallow(<Single server={server} />);
+      const component = shallow(<Single server={server} isDataLake={false}/>);
 
       it('renders the address', () => {
         const node = component.find(`.${styles['topology-single-address']}`);
@@ -133,6 +133,21 @@ describe('<Single />', () => {
       it('renders the humanized type', () => {
         const node = component.find(`.${styles['topology-single-type']}`);
         expect(node).to.have.text('Possible Primary');
+      });
+    });
+
+    context('when connected to DataLake', () => {
+      const server = { address: '127.0.0.1:27017', type: STANDALONE };
+      const component = shallow(<Single server={server} isDataLake/>);
+
+      it('renders the address', () => {
+        const node = component.find(`.${styles['topology-single-address']}`);
+        expect(node).to.have.text('127.0.0.1:27017');
+      });
+
+      it('does not renders the humanized type', () => {
+        const node = component.find(`.${styles['topology-single-type']}`);
+        expect(node).to.be.not.present();
       });
     });
   });

--- a/src/components/unknown.jsx
+++ b/src/components/unknown.jsx
@@ -11,7 +11,8 @@ class Unknown extends React.Component {
   static displayName = 'Unknown';
 
   static propTypes = {
-    servers: PropTypes.array.isRequired
+    servers: PropTypes.array.isRequired,
+    isDataLake: PropTypes.bool.isRequired
   }
 
   /**
@@ -27,6 +28,15 @@ class Unknown extends React.Component {
     return `${count} server`;
   }
 
+  renderPill() {
+    return (
+      <div className={classnames(styles['topology-unknown-type'])}>
+        <i className="mms-icon-unknown" />
+        <span className={classnames(styles['topology-unknown-type-name'])}>Unknown</span>
+      </div>
+    );
+  }
+
   /**
    * Render the unknown component.
    *
@@ -38,10 +48,7 @@ class Unknown extends React.Component {
         <div className={classnames(styles['topology-unknown-name'])}>
           Unknown
         </div>
-        <div className={classnames(styles['topology-unknown-type'])}>
-          <i className="mms-icon-unknown" />
-          <span className={classnames(styles['topology-unknown-type-name'])}>Unknown</span>
-        </div>
+        { this.props.isDataLake ? null : this.renderPill() }
         <div className={classnames(styles['topology-unknown-nodes'])}>
           {this.renderServerCount()}
         </div>

--- a/src/components/unknown.spec.js
+++ b/src/components/unknown.spec.js
@@ -12,7 +12,7 @@ describe('<Unknown />', () => {
   describe('#render', () => {
     context('when the set has 1 node', () => {
       const servers = [{ address: '127.0.0.1:27017', type: RS_PRIMARY }];
-      const component = shallow(<Unknown servers={servers} />);
+      const component = shallow(<Unknown servers={servers} isDataLake={false} />);
 
       it('renders the name', () => {
         const node = component.find(`.${styles['topology-unknown-name']}`);
@@ -40,7 +40,7 @@ describe('<Unknown />', () => {
         { address: '127.0.0.1:27017', type: RS_PRIMARY },
         { address: '127.0.0.1:27018', type: RS_SECONDARY }
       ];
-      const component = shallow(<Unknown servers={servers} />);
+      const component = shallow(<Unknown servers={servers} isDataLake={false} />);
 
       it('renders the name', () => {
         const node = component.find(`.${styles['topology-unknown-name']}`);
@@ -60,6 +60,26 @@ describe('<Unknown />', () => {
       it('renders the unknown text', () => {
         const node = component.find(`.${styles['topology-unknown-type-name']}`);
         expect(node).to.have.text('Unknown');
+      });
+    });
+
+    context('connected to DataLake', () => {
+      const servers = [{ address: '127.0.0.1:27017', type: RS_PRIMARY }];
+      const component = shallow(<Unknown servers={servers} isDataLake />);
+
+      it('renders the name', () => {
+        const node = component.find(`.${styles['topology-unknown-name']}`);
+        expect(node).to.have.text('Unknown');
+      });
+
+      it('renders the node count', () => {
+        const node = component.find(`.${styles['topology-unknown-nodes']}`);
+        expect(node).to.have.text('1 server');
+      });
+
+      it('renders the unknown text', () => {
+        const node = component.find(`.${styles['topology-unknown-type-name']}`);
+        expect(node).to.be.not.present();
       });
     });
   });

--- a/src/stores/index.js
+++ b/src/stores/index.js
@@ -21,6 +21,11 @@ const DeploymentAwarenessStore = Reflux.createStore({
    */
   onActivated(appRegistry) {
     appRegistry.on('data-service-initialized', this.onDataServiceInitialized.bind(this));
+    appRegistry.on('instance-refreshed', (state) => {
+      if (state.instance.dataLake && state.instance.dataLake.isDataLake) {
+        this.setState({isDataLake: true});
+      }
+    });
   },
 
   /**
@@ -52,7 +57,8 @@ const DeploymentAwarenessStore = Reflux.createStore({
     return {
       topologyType: 'Unknown',
       setName: '',
-      servers: []
+      servers: [],
+      isDataLake: false
     };
   }
 });


### PR DESCRIPTION
Right now will skip the pill for standalone and unknown types. If needed, I can also add support for skipping the pill for replset / sharded but I'm not sure if that will ever be triggered by DataLake.